### PR TITLE
Update functions-called-by-mixcraft.md

### DIFF
--- a/docs/API Sections/functions-called-by-mixcraft.md
+++ b/docs/API Sections/functions-called-by-mixcraft.md
@@ -81,7 +81,7 @@ The ```OnMIDI()``` function is called when a MIDI message is received at the def
 - MIDI.NOTE_OFF (128)
 - MIDI.NOTE_ON (144)
 - MIDI.POLY_PRESSURE (160)
-- MIDI.CC_MESSAGE (167)
+- MIDI.CC_MESSAGE (176)
 - MIDI.PROGRAM_CHANGE (192)
 - MIDI.CHANNEL_PRESSURE (208)
 - MIDI.PITCH_BEND (224)


### PR DESCRIPTION
Fixing typo
Decimal `167` != Hex `B0`

Looks like `167` and `176` was just a transposition of the `6` and `7` which I do ALL THE TIME (with all the numbers 😄 )